### PR TITLE
fix syntax error

### DIFF
--- a/sensniff.py
+++ b/sensniff.py
@@ -170,7 +170,7 @@ class SerialInputHandler(object):
             per_out = self.port.readline().rstrip()
             try:
                 logger.info("Peripheral: %s%s" % (b.decode(), per_out.decode()))
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 logger.info("Error decoding peripheral output: %s"%e)
             stats['Non-Frame'] += 1
             return ''


### PR DESCRIPTION
The last commit introduced syntax error on python 3. This commit fixes the issue.

```python
  File "sensniff.py", line 173
    except UnicodeDecodeError, e:
                             ^
SyntaxError: invalid syntax
```